### PR TITLE
新增日期的格式化选择

### DIFF
--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -151,7 +151,7 @@
                         'text-blue-600 font-bold text-18px dark:text-white':
                           按钮停止状态
                       }"
-                      @click="复制(底部动态时间戳)"
+                      @click="clickTimestamp(底部动态时间戳)"
                     >
                       {{ 底部动态时间戳 }}
                     </span>
@@ -288,14 +288,14 @@ const formats = useStorage('formats', [
   'YYYY年MM月DD日 HH时mm分ss秒'
 ])
 const formatString = ref(formats.value[0])
-const formatChange = (value) => {
+function formatChange(value) {
   if (! formats.value.includes(value)) {
     formats.value.push(value)
     utools.dbStorage.setItem('formats', formats.value)
   }
   console.log(formats)
 }
-const delFormat = (format) => {
+function delFormat(format) {
   if (formats.value.length !== 1) {
     formats.value = formats.value.filter(f => f !== format)
     if (formatString.value === format) {
@@ -366,6 +366,12 @@ onMounted(() => {
   utoolsInit()
 })
 
+// 点击当前时间戳时
+function clickTimestamp(timestamp) {
+  // 填充时间戳转日期的输入框
+  formData.time = timestamp
+  复制(timestamp)
+}
 const 按钮停止状态 = ref(false) // 按钮状态，是否停止
 // 开始/停止按钮
 function 暂停开始按钮() {

--- a/src/components/HomeView.vue
+++ b/src/components/HomeView.vue
@@ -312,6 +312,14 @@ function 重置数据() {
   formData.time = undefined
   时间戳类型.value = 'ms'
   时区.value = 'Asia/Shanghai'
+  formats.value = [
+    'YYYY-MM-DD HH:mm:ss',
+    'ddd, D MMM YYYY HH:mm:ss Z',
+    'YYYY-MM-DDTHH:mm:ssZ',
+    'YYYY-MM-DDTHH:mm:ss',
+    'YYYY年MM月DD日 HH时mm分ss秒'
+  ]
+  utools.dbStorage.setItem('formats', formats.value)
   Message.success({ content: '已重置', duration: 1000 })
 }
 


### PR DESCRIPTION
### 修改项：
1. 新增日期的格式化选择，可自定义，可删除，重置数据可恢复默认值
2. 点击时间戳自动填充时间戳转日期的输入框，并复制时间戳
3. 修改日期选择器展开位置为 right
4. 缩短两个格式转换输入框的宽度

### 示例图
![image](https://github.com/user-attachments/assets/e5c913d6-efec-47e0-bc3f-3e9f43c8a4a7)

![image](https://github.com/user-attachments/assets/3cba56fe-0688-4f33-bc59-83d59f64080f)
